### PR TITLE
[#74] rem 인스트럭션 컴파일 구현

### DIFF
--- a/src/ir/ast/local/instruction.rs
+++ b/src/ir/ast/local/instruction.rs
@@ -5,6 +5,7 @@ pub mod call;
 pub mod compare;
 pub mod div;
 pub mod mul;
+pub mod rem;
 pub mod return_;
 pub mod sub;
 
@@ -16,6 +17,7 @@ pub enum InstructionStatement {
     Sub(sub::SubInstruction),
     Mul(mul::MulInstruction),
     Div(div::DivInstruction),
+    Rem(rem::RemInstruction),
     Branch(branch::BranchInstruction),
     Jump(branch::JumpInstruction),
     Compare(compare::CompareInstruction),
@@ -57,6 +59,12 @@ impl From<mul::MulInstruction> for InstructionStatement {
 impl From<div::DivInstruction> for InstructionStatement {
     fn from(instr: div::DivInstruction) -> Self {
         InstructionStatement::Div(instr)
+    }
+}
+
+impl From<rem::RemInstruction> for InstructionStatement {
+    fn from(instr: rem::RemInstruction) -> Self {
+        InstructionStatement::Rem(instr)
     }
 }
 

--- a/src/ir/ast/local/instruction/rem.rs
+++ b/src/ir/ast/local/instruction/rem.rs
@@ -1,0 +1,9 @@
+use crate::ir::ast::common::Operand;
+
+/// REM 인스트럭션
+/// 나머지셈 연산을 수행합니다.
+#[derive(Debug)]
+pub struct RemInstruction {
+    pub left: Operand,
+    pub right: Operand,
+}

--- a/src/ir/compile/linux_amd64/mod.rs
+++ b/src/ir/compile/linux_amd64/mod.rs
@@ -15,6 +15,7 @@ pub mod constant;
 pub mod div;
 pub mod function;
 pub mod mul;
+pub mod rem;
 pub mod return_;
 pub mod statements;
 pub mod sub;
@@ -1845,6 +1846,248 @@ mod tests {
                                             crate::ir::ast::local::instruction::div::DivInstruction {
                                                 left: crate::ir::ast::common::Operand::Literal(
                                                     LiteralValue::Int32(15),
+                                                ),
+                                                right: crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::Int32(5),
+                                                ),
+                                            }
+                                        ),
+                                    ),
+                                }.into(),
+                                // printf("%lld\n", result)
+                                LocalStatement::Instruction(InstructionStatement::Call(
+                                    CallInstruction {
+                                        function_name: "printf".into(),
+                                        parameters: vec![
+                                            crate::ir::ast::common::Operand::Literal(
+                                                LiteralValue::String("%lld\n".into()),
+                                            ),
+                                            crate::ir::ast::common::Operand::Identifier("result".into()),
+                                        ],
+                                    },
+                                )),
+                            ],
+                        },
+                    })],
+                },
+            },
+            TestCase {
+                name: "REM 명령어 테스트 - Int64 리터럴 나머지",
+                expected_output: "10\n",
+                want_error: false,
+                expected_error: None,
+                code_unit: CodeUnit {
+                    filename: "rem_int64_literal.foolang".into(),
+                    statements: vec![GlobalStatement::DefineFunction(FunctionDefinition {
+                        function_name: "main".into(),
+                        arguments: vec![],
+                        return_type: IRPrimitiveType::Void.into(),
+                        function_body: LocalStatements {
+                            statements: vec![
+                                // result = rem 100, 30
+                                AssignmentStatement {
+                                    name: "result".into(),
+                                    value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                        InstructionStatement::Rem(
+                                            crate::ir::ast::local::instruction::rem::RemInstruction {
+                                                left: crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::Int64(100),
+                                                ),
+                                                right: crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::Int64(30),
+                                                ),
+                                            }
+                                        ),
+                                    ),
+                                }.into(),
+                                // printf("%lld\n", result)
+                                LocalStatement::Instruction(InstructionStatement::Call(
+                                    CallInstruction {
+                                        function_name: "printf".into(),
+                                        parameters: vec![
+                                            crate::ir::ast::common::Operand::Literal(
+                                                LiteralValue::String("%lld\n".into()),
+                                            ),
+                                            crate::ir::ast::common::Operand::Identifier("result".into()),
+                                        ],
+                                    },
+                                )),
+                            ],
+                        },
+                    })],
+                },
+            },
+            TestCase {
+                name: "REM 명령어 테스트 - 변수 간 나머지",
+                expected_output: "4\n",
+                want_error: false,
+                expected_error: None,
+                code_unit: CodeUnit {
+                    filename: "rem_identifier_identifier.foolang".into(),
+                    statements: vec![
+                        GlobalStatement::DefineFunction(FunctionDefinition {
+                            function_name: "main".into(),
+                            arguments: vec![],
+                            return_type: IRPrimitiveType::Void.into(),
+                            function_body: LocalStatements {
+                                statements: vec![
+                                    // x = 60
+                                    AssignmentStatement {
+                                        name: "x".into(),
+                                        value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                            InstructionStatement::Call(CallInstruction {
+                                                function_name: "get_sixty".into(),
+                                                parameters: vec![],
+                                            }),
+                                        ),
+                                    }.into(),
+                                    // y = 7
+                                    AssignmentStatement {
+                                        name: "y".into(),
+                                        value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                            InstructionStatement::Call(CallInstruction {
+                                                function_name: "get_seven".into(),
+                                                parameters: vec![],
+                                            }),
+                                        ),
+                                    }.into(),
+                                    // result = rem x, y
+                                    AssignmentStatement {
+                                        name: "result".into(),
+                                        value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                            InstructionStatement::Rem(
+                                                crate::ir::ast::local::instruction::rem::RemInstruction {
+                                                    left: crate::ir::ast::common::Operand::Identifier("x".into()),
+                                                    right: crate::ir::ast::common::Operand::Identifier("y".into()),
+                                                }
+                                            ),
+                                        ),
+                                    }.into(),
+                                    // printf("%lld\n", result)
+                                    LocalStatement::Instruction(InstructionStatement::Call(
+                                        CallInstruction {
+                                            function_name: "printf".into(),
+                                            parameters: vec![
+                                                crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::String("%lld\n".into()),
+                                                ),
+                                                crate::ir::ast::common::Operand::Identifier("result".into()),
+                                            ],
+                                        },
+                                    )),
+                                ],
+                            },
+                        }),
+                        GlobalStatement::DefineFunction(FunctionDefinition {
+                            function_name: "get_sixty".into(),
+                            arguments: vec![],
+                            return_type: IRPrimitiveType::Int64.into(),
+                            function_body: LocalStatements {
+                                statements: vec![LocalStatement::Instruction(
+                                    InstructionStatement::Return(crate::ir::ast::local::instruction::return_::ReturnInstruction {
+                                        return_value: Some(crate::ir::ast::common::Operand::Literal(LiteralValue::Int64(60))),
+                                    }),
+                                )],
+                            },
+                        }),
+                        GlobalStatement::DefineFunction(FunctionDefinition {
+                            function_name: "get_seven".into(),
+                            arguments: vec![],
+                            return_type: IRPrimitiveType::Int64.into(),
+                            function_body: LocalStatements {
+                                statements: vec![LocalStatement::Instruction(
+                                    InstructionStatement::Return(crate::ir::ast::local::instruction::return_::ReturnInstruction {
+                                        return_value: Some(crate::ir::ast::common::Operand::Literal(LiteralValue::Int64(7))),
+                                    }),
+                                )],
+                            },
+                        }),
+                    ],
+                },
+            },
+            TestCase {
+                name: "REM 명령어 테스트 - 체이닝 나머지",
+                expected_output: "6\n",
+                want_error: false,
+                expected_error: None,
+                code_unit: CodeUnit {
+                    filename: "rem_chaining.foolang".into(),
+                    statements: vec![
+                        GlobalStatement::DefineFunction(FunctionDefinition {
+                            function_name: "main".into(),
+                            arguments: vec![],
+                            return_type: IRPrimitiveType::Void.into(),
+                            function_body: LocalStatements {
+                                statements: vec![
+                                    // temp = rem 200, 60
+                                    AssignmentStatement {
+                                        name: "temp".into(),
+                                        value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                            InstructionStatement::Rem(
+                                                crate::ir::ast::local::instruction::rem::RemInstruction {
+                                                    left: crate::ir::ast::common::Operand::Literal(
+                                                        LiteralValue::Int64(200),
+                                                    ),
+                                                    right: crate::ir::ast::common::Operand::Literal(
+                                                        LiteralValue::Int64(60),
+                                                    ),
+                                                }
+                                            ),
+                                        ),
+                                    }.into(),
+                                    // result = rem temp, 7
+                                    AssignmentStatement {
+                                        name: "result".into(),
+                                        value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                            InstructionStatement::Rem(
+                                                crate::ir::ast::local::instruction::rem::RemInstruction {
+                                                    left: crate::ir::ast::common::Operand::Identifier("temp".into()),
+                                                    right: crate::ir::ast::common::Operand::Literal(
+                                                        LiteralValue::Int64(7),
+                                                    ),
+                                                }
+                                            ),
+                                        ),
+                                    }.into(),
+                                    // printf("%lld\n", result)
+                                    LocalStatement::Instruction(InstructionStatement::Call(
+                                        CallInstruction {
+                                            function_name: "printf".into(),
+                                            parameters: vec![
+                                                crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::String("%lld\n".into()),
+                                                ),
+                                                crate::ir::ast::common::Operand::Identifier("result".into()),
+                                            ],
+                                        },
+                                    )),
+                                ],
+                            },
+                        }),
+                    ],
+                },
+            },
+            TestCase {
+                name: "REM 명령어 테스트 - Int32 리터럴 나머지",
+                expected_output: "2\n",
+                want_error: false,
+                expected_error: None,
+                code_unit: CodeUnit {
+                    filename: "rem_int32_literal.foolang".into(),
+                    statements: vec![GlobalStatement::DefineFunction(FunctionDefinition {
+                        function_name: "main".into(),
+                        arguments: vec![],
+                        return_type: IRPrimitiveType::Void.into(),
+                        function_body: LocalStatements {
+                            statements: vec![
+                                // result = rem 17, 5
+                                AssignmentStatement {
+                                    name: "result".into(),
+                                    value: crate::ir::ast::local::assignment::AssignmentStatementValue::Instruction(
+                                        InstructionStatement::Rem(
+                                            crate::ir::ast::local::instruction::rem::RemInstruction {
+                                                left: crate::ir::ast::common::Operand::Literal(
+                                                    LiteralValue::Int32(17),
                                                 ),
                                                 right: crate::ir::ast::common::Operand::Literal(
                                                     LiteralValue::Int32(5),

--- a/src/ir/compile/linux_amd64/rem.rs
+++ b/src/ir/compile/linux_amd64/rem.rs
@@ -1,0 +1,82 @@
+use crate::{
+    ir::{
+        ast::local::instruction::rem::RemInstruction,
+        compile::linux_amd64::{
+            common::{emit_rex_prefix, load_operand_to_register, validate_operand_types},
+            function::FunctionContext,
+        },
+        error::IRError,
+    },
+    platforms::{
+        amd64::{
+            instruction::Instruction,
+            register::{modrm_digit_reg, modrm_reg_reg, Register},
+            rex::RexPrefix,
+        },
+        linux::elf::object::ELFObject,
+    },
+};
+
+/// REM 인스트럭션 컴파일
+///
+/// 전략:
+/// 1. 두 operand의 타입 검증 (정수끼리만 가능)
+/// 2. left operand(피제수)를 RAX에 로드
+/// 3. CQO 명령으로 RAX를 RDX:RAX로 sign-extend
+/// 4. right operand(제수)를 RCX에 로드
+/// 5. IDIV RCX 명령 생성 (몫은 RAX에, 나머지는 RDX에 저장됨)
+/// 6. RDX(나머지)를 RAX로 이동
+pub fn compile_rem_instruction(
+    rem_instruction: &RemInstruction,
+    context: &mut FunctionContext,
+    object: &mut ELFObject,
+) -> Result<(), IRError> {
+    // Step 1: 타입 검증
+    validate_operand_types(
+        &rem_instruction.left,
+        &rem_instruction.right,
+        context,
+        "REM",
+    )?;
+
+    // Step 2: left operand(피제수)를 RAX에 로드
+    load_operand_to_register(&rem_instruction.left, Register::RAX, context, object)?;
+
+    // Step 3: CQO - RAX를 RDX:RAX로 sign-extend
+    // REX.W + 99 (CQO: sign-extend RAX into RDX:RAX)
+    object.text_section.data.push(RexPrefix::RexW as u8);
+    object
+        .text_section
+        .data
+        .extend_from_slice(&Instruction::Cqo.as_bytes()); // CQO (0x99)
+
+    // Step 4: right operand(제수)를 RCX에 로드
+    load_operand_to_register(&rem_instruction.right, Register::RCX, context, object)?;
+
+    // Step 5: IDIV RCX 명령 생성
+    // REX.W + F7 /7 (IDIV r/m64)
+    // 몫은 RAX에, 나머지는 RDX에 저장
+    object.text_section.data.push(RexPrefix::RexW as u8);
+    object
+        .text_section
+        .data
+        .extend_from_slice(&Instruction::IDiv.as_bytes()); // IDIV opcode (0xF7)
+
+    // ModR/M: Mod=11 (register direct), Reg=/7 (IDIV extension), R/M=RCX
+    let digit = Instruction::IDiv.modrm_extension().unwrap(); // /7
+    object
+        .text_section
+        .data
+        .push(modrm_digit_reg(digit, Register::RCX));
+
+    // Step 6: RDX(나머지)를 RAX로 이동
+    // MOV RAX, RDX
+    emit_rex_prefix(object, Some(Register::RAX), Some(Register::RDX));
+    object.text_section.data.push(Instruction::MovLoad as u8);
+    object
+        .text_section
+        .data
+        .push(modrm_reg_reg(Register::RAX, Register::RDX));
+
+    Ok(())
+}

--- a/src/ir/compile/linux_amd64/statements.rs
+++ b/src/ir/compile/linux_amd64/statements.rs
@@ -17,6 +17,7 @@ use crate::{
             div::compile_div_instruction,
             function::FunctionContext,
             mul::compile_mul_instruction,
+            rem::compile_rem_instruction,
             return_::compile_return_instruction,
             sub::compile_sub_instruction,
         },
@@ -89,6 +90,9 @@ fn compile_assignment_statement(
         }
         AssignmentStatementValue::Instruction(InstructionStatement::Div(instruction)) => {
             compile_div_instruction(instruction, context, object)?;
+        }
+        AssignmentStatementValue::Instruction(InstructionStatement::Rem(instruction)) => {
+            compile_rem_instruction(instruction, context, object)?;
         }
         AssignmentStatementValue::Instruction(InstructionStatement::Call(instruction)) => {
             // call instruction 컴파일 (결과는 RAX에)
@@ -198,6 +202,12 @@ fn compile_instruction_statement(
             return Err(IRError::new(
                 IRErrorKind::AssignmentRequired,
                 "Div instruction need assignment",
+            ));
+        }
+        InstructionStatement::Rem(_) => {
+            return Err(IRError::new(
+                IRErrorKind::AssignmentRequired,
+                "Rem instruction need assignment",
             ));
         }
         InstructionStatement::Branch(instruction) => {


### PR DESCRIPTION
resolves: #74

## Description

- AST 추가 및 linux-amd64 컴파일 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 나머지(REM) 연산 지원이 추가되었습니다. Linux AMD64 환경에서 정수 나머지 연산을 컴파일할 수 있으며, 리터럴 값과 식별자 간의 나머지 연산, 체이닝된 연산 등 다양한 시나리오를 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->